### PR TITLE
Fix compilation with GCC-10 based compilers

### DIFF
--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -13,6 +13,7 @@
 
 #include <cstring>
 #include <exception>
+#include <stdexcept>
 #include <functional>
 #include <memory>
 #include <set>


### PR DESCRIPTION
This tiny PR aims to allow compilation (static or dynamic) with GCC-10 based compiler on any Linux machine, either with -std=c++11 or (unnecessary here) -std=c++17